### PR TITLE
feat: `from` with prefix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        node-version: [ 18, 24 ]
+        node-version: [ 24 ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/main/js/cli.js
+++ b/src/main/js/cli.js
@@ -35,8 +35,8 @@ if (argv.v || argv.version) {
 }
 
 await copy({
-  from:         argv._[0],
-  to:           argv._[1],
+  from:         argv.from || argv._[0],
+  to:           argv.to || argv._[1],
   msg:          argv.m || argv.message,
   cwd:          argv.C || argv.cwd,
   ignoreFiles:  argv.i || argv.ignoreFiles

--- a/src/main/js/index.js
+++ b/src/main/js/index.js
@@ -1,8 +1,8 @@
 import { pipeline, Readable } from 'node:stream'
 import { promisify } from 'node:util'
-import { fs, path, tempy, $ as _$, fetch, copy as _copy } from 'zx-extra'
+import { fs, tempy, $ as _$, fetch, copy as _copy } from 'zx-extra'
 import * as tar from 'tar'
-import { parse } from './parse.js'
+import { parseArgs } from './parse.js'
 
 export const copy = async (opts = {}, ...rest) => {
   // Legacy support for old signature
@@ -31,22 +31,6 @@ export const copy = async (opts = {}, ...rest) => {
   })
 
   if (dst.type === 'git') await gitPush(dst, msg)
-}
-
-const parseArgs = (
-  from,
-  to,
-  msg = 'chore: sync',
-  ignoreFiles,
-  _cwd
-) => {
-  const cwd = path.resolve(process.cwd(), _cwd || '.')
-  const src = parse(from, {cwd, defaultPattern: '**/*'})
-  const dst = parse(to, {cwd, defaultPattern: '.'})
-
-  if (/[{}*,!]/.test(dst.pattern)) throw new Error('`dest` must not be a glob')
-
-  return {src, dst, msg}
 }
 
 const unpackArchive = async (src) => {

--- a/src/main/js/parse.js
+++ b/src/main/js/parse.js
@@ -1,5 +1,23 @@
 import {path, tempy} from 'zx-extra'
 
+export const parseArgs = (
+  from,
+  to,
+  msg = 'chore: sync',
+  ignoreFiles,
+  _cwd
+) => {
+  const [f, c] = from.split('>', 2).reverse()
+  const cwd = path.resolve(process.cwd(), _cwd || '.')
+  const srcCwd = c ? path.resolve(process.cwd(), c) : cwd
+  const src = parse(f, {cwd: srcCwd, defaultPattern: '**/*'})
+  const dst = parse(to, {cwd, defaultPattern: '.'})
+
+  if (/[{}*,!]/.test(dst.pattern)) throw new Error('`dest` must not be a glob')
+
+  return {src, dst, msg}
+}
+
 export const parse = (target, {cwd = process.cwd(), temp = tempy.temporaryDirectory(), defaultPattern} = {}) =>
   parseGitRef(target, {temp, defaultPattern}) ||
   parseArchiveRef(target, {temp, cwd, defaultPattern}) ||

--- a/src/test/js/index.test.js
+++ b/src/test/js/index.test.js
@@ -4,7 +4,7 @@ import { $, tempy, path, fs } from 'zx-extra'
 import * as tar from 'tar'
 
 import { copy } from '../../main/js/index.js'
-import { parse } from '../../main/js/parse.js'
+import { parse, parseArgs } from '../../main/js/parse.js'
 
 const $r = $({quote: v => v})
 
@@ -140,6 +140,35 @@ describe('JS API', () => {
 
     assert.ok((!await fs.pathExists(path.resolve(temp, 'package/package.json'))))
     assert.ok((await fs.pathExists(path.resolve(temp, 'package/src/main/js/index.js'))))
+  })
+
+  test('parseArgs()', () => {
+    const cases = [
+      {
+        input: ['foo/bar>sub/**/*', 'target/dir'],
+        expected: {
+          src: {
+            base: path.resolve(process.cwd(), 'foo/bar'),
+            pattern: 'sub/**/*',
+            raw: 'sub/**/*',
+            type: 'local'
+          },
+          dst: {
+            base: process.cwd(),
+            pattern: 'target/dir',
+            raw: 'target/dir',
+            type: 'local'
+          },
+          msg: 'chore: sync'
+        }
+      }
+    ]
+
+    for (const { input, expected } of cases) {
+      const result = parseArgs(...input)
+      assert.deepEqual(result.src, expected.src)
+      assert.deepEqual(result.dst, expected.dst)
+    }
   })
 
   test('parse()', () => {


### PR DESCRIPTION
`--from='foo/bar>baz/**/*'` splits into `cwd: foo/bar` and `pattern: baz/**/*`

- [x] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
